### PR TITLE
Legibility Improvement

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Container from "./Container"
 
 const Footer = () => (
     <Container className="flex flex-col pb-8 text-sm">
-        <span className="text-gray-800 mx-auto">Made by <a href="https://uly.dev" className="text-green-500 hover:text-green-900" target="_blank" rel="noreferrer noopener">ulydev</a>. Enjoying it? Buy me a coffee at</span>
+        <span className="text-gray-600 mx-auto">Made by <a href="https://uly.dev" className="text-green-500 hover:text-green-900" target="_blank" rel="noreferrer noopener">ulydev</a>. Enjoying it? Buy me a coffee at</span>
         <span className="text-gray-500 mx-auto">0xffd91D21aada737a54902E5C09f4af5A8E52252D</span>
     </Container>
 )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { useWeb3React } from "@web3-react/core"
 import { useCapBalance } from "../hooks/useCapBalance"
 
 import logo from "../images/logo.svg"
-import { AiOutlinePlusCircle, AiOutlinePoweroff, AiOutlineSetting } from "react-icons/ai"
+import { AiOutlinePlusCircle } from "react-icons/ai"
 import { getTokenContract, useContract } from "../hooks/useContract"
 import { useStoreActions } from "../state/hooks"
 import { toast } from "react-toastify"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,12 +52,16 @@ const Account = () => {
                 <NavLink
                     to="/settings"
                     className="opacity-50 hover:opacity-100 transition duration-200 text-lg">
-                    <AiOutlineSetting />
+                    <button className="bg-transparent hover:bg-grey-500 text-grey-700 font-semibold text-xs hover:text-white py-1 px-2 border border-grey-500 hover:border-transparent rounded">
+                        Stake
+                    </button>
                 </NavLink>
                 <button
                     onClick={deactivate}
                     className="opacity-50 hover:opacity-100 transition duration-200 text-lg">
-                    <AiOutlinePoweroff />
+                    <button className="bg-transparent hover:bg-grey-500 text-grey-700 font-semibold text-xs hover:text-white py-1 px-2 border border-grey-500 hover:border-transparent rounded">
+                        Disconnect
+                    </button>
                 </button>
             </div>
         </div> 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -60,7 +60,7 @@ const Settings = () => {
                 <div className="absolute pattern-dots-sm text-green-500 text-opacity-50 left-0 top-0 w-8 h-8 -ml-4 -mt-1" />
                 <label htmlFor="stakedCap" className="mb-2 flex flex-row justify-between">
                     <span>Staked CAP</span>
-                    <span className="text-gray-800">Default: 10 CAP</span>
+                    <span className="text-gray-600">Default: 10 CAP</span>
                 </label>
                 <CurrencyInput
                     className="p-2 px-4 text-white bg-green-900 bg-opacity-25 border-green-500 border-b-2"

--- a/src/components/proposals/NewProposal.tsx
+++ b/src/components/proposals/NewProposal.tsx
@@ -58,7 +58,7 @@ const ProposalForm = () => {
                 <div className="absolute pattern-dots-sm text-green-500 text-opacity-50 left-0 top-0 w-8 h-8 -ml-4 -mt-1" />
                 <label htmlFor="discoverabilityPeriod" className="mb-2 flex flex-row justify-between">
                     <span>Discoverability period (# blocks)</span>
-                    <span className="text-gray-800">1 hour ~= 272 blocks</span>
+                    <span className="text-gray-600">1 hour ~= 272 blocks</span>
                 </label>
                 <input className="p-2 px-4 text-white bg-green-900 bg-opacity-25 border-green-500 border-b-2" name="discoverabilityPeriod" placeholder="100" type="number" ref={register({ required: true })} />
             </div>
@@ -67,12 +67,12 @@ const ProposalForm = () => {
                     <div className="absolute pattern-dots-sm text-green-500 text-opacity-50 left-0 top-0 w-8 h-8 -ml-4 -mt-1" />
                     <span>Operations</span>
                     <div className="flex flex-row items-center">
-                        <span className="text-gray-800">{ operations.length }</span>
+                        <span className="text-gray-600">{ operations.length }</span>
                         <button
                             type="button"
                             className={classnames(
                                 "border-b-2 p-2 ml-4",
-                                operations.length === maxOperations ? "text-gray-800 border-gray-800" : "text-green-500 border-green-500 hover:bg-green-500 hover:text-white transition duration-200"
+                                operations.length === maxOperations ? "text-gray-600 border-gray-800" : "text-green-500 border-green-500 hover:bg-green-500 hover:text-white transition duration-200"
                             )}
                             disabled={operations.length === maxOperations}
                             onClick={() => { if (operations.length < maxOperations) addOperation({}) }}><FiPlus /></button>
@@ -83,12 +83,12 @@ const ProposalForm = () => {
                         return (
                             <div key={index} className="flex flex-col border-b-2 border-gray-800">
                                 <div className="flex flex-row items-center justify-between mb-2">
-                                    <h1 className="text-gray-800">Operation #{index+1}</h1>
+                                    <h1 className="text-gray-600">Operation #{index+1}</h1>
                                     <button
                                         type="button"
                                         className={classnames(
                                             "border-b-2 p-2 ml-4",
-                                            operations.length === maxOperations ? "text-gray-800 border-gray-800" : "text-red-500 border-red-500 hover:bg-red-500 hover:text-white transition duration-200"
+                                            operations.length === maxOperations ? "text-gray-600 border-gray-800" : "text-red-500 border-red-500 hover:bg-red-500 hover:text-white transition duration-200"
                                         )}
                                         onClick={() => removeOperation(index)}><FiMinus /></button>
                                 </div>

--- a/src/components/proposals/Proposal.tsx
+++ b/src/components/proposals/Proposal.tsx
@@ -77,7 +77,7 @@ const VoteButton: FunctionComponent<{ proposal: ProposalType, endTimestamp: numb
             )}>
             <div className="flex flex-col flex-1 border-b-2 border-gray-500 flex-1 text-left pb-1">
                 <span className="text-gray-500">Voting</span>
-                <span className="text-xs text-gray-800 font-normal">ends in { useCountdown(endTimestamp) }</span>
+                <span className="text-xs text-gray-600 font-normal">ends in { useCountdown(endTimestamp) }</span>
             </div>
             { needsAllowance ? (
                 <button onClick={allowSpend} className="text-gray-500 border-b-2 px-4 border-gray-500 hover:text-white hover:bg-gray-500 transition duration-500">Approve CAP</button>
@@ -144,39 +144,39 @@ const ProposalView: FunctionComponent<{ proposal: ProposalType, full: boolean }>
                 <div className="relative flex flex-row justify-between space-x-2">
                     <div className="absolute pattern-dots-sm text-green-500 text-opacity-50 left-0 top-0 w-8 h-8 -ml-2 -mt-1" />
                     <Link to={`/proposal/${proposal.id}`} className="flex-1 font-bold text-white hover:text-green-500" style={{ minHeight: "4rem" }}>{ full ? proposal.description : truncate(proposal.description, 44) }</Link>
-                    <span className="text-gray-800">#{ proposal.id.toNumber() }</span>
+                    <span className="text-gray-600">#{ proposal.id.toNumber() }</span>
                 </div>
                 <div className="flex flex-row justify-between text-sm mt-8">
-                    <span className="text-gray-800">Proposed by</span>
+                    <span className="text-gray-600">Proposed by</span>
                     <a
                         className="text-gray-500 flex flex-row items-center space-x-1 hover:text-green-500 transition duration-200"
                         href={`https://${chainId === ChainId.MAINNET ? "" : `${ChainId[chainId!].toLowerCase()}.`}etherscan.io/address/${proposal.proposer}`}
                         target="_blank" rel="noreferrer noopener">
-                        <span>{ formatAccount(proposal.proposer) }</span><RiExternalLinkLine className="text-gray-800" />
+                        <span>{ formatAccount(proposal.proposer) }</span><RiExternalLinkLine className="text-gray-600" />
                     </a>
                 </div>
                 <div className="flex flex-col mt-2">
                     <div className="flex flex-row justify-between text-sm">
-                        <span className="text-gray-800">Vote start</span>
+                        <span className="text-gray-600">Vote start</span>
                         <span className="text-gray-500">{ startTimestamp ? (new Date(startTimestamp * 1000).toLocaleString()) : null }</span>
                     </div>
                     <div className="flex flex-row justify-between text-sm">
-                        <span className="text-gray-800">Vote end</span>
+                        <span className="text-gray-600">Vote end</span>
                         <span className="text-gray-500">{ endTimestamp ? (new Date(endTimestamp * 1000).toLocaleString()) : null }</span>
                     </div>
                 </div>
                 <div className="flex flex-row justify-between text-sm mt-2">
-                    <span className="text-gray-800">Expires</span>
+                    <span className="text-gray-600">Expires</span>
                     <span className="text-gray-500">{ expirationTimestamp ? (new Date(expirationTimestamp * 1000).toLocaleString()) : null }</span>
                 </div>
             </div>
             <div className="flex flex-col w-full mt-8">
                 <div className="flex flex-row w-full justify-between">
-                    <span className="text-green-900">{ convertBigNumber(proposal.forVotes).toSignificant(4) }{ hasVotes ? ` (${ percentageVoted }%)` : null }</span>
-                    <span className="text-red-900">{ convertBigNumber(proposal.againstVotes).toSignificant(4) }{ hasVotes ? ` (${ 100 - percentageVoted }%)` : null }</span>
+                    <span className="text-green-600">{ convertBigNumber(proposal.forVotes).toSignificant(4) }{ hasVotes ? ` (${ percentageVoted }%)` : null }</span>
+                    <span className="text-red-600">{ convertBigNumber(proposal.againstVotes).toSignificant(4) }{ hasVotes ? ` (${ 100 - percentageVoted }%)` : null }</span>
                 </div>
-                <div className="flex flex-row w-full bg-red-900 items-center" style={{ height: "0.125rem" }}>
-                    <div className="bg-green-900 h-full" style={{ width: `${percentageVoted}%` }} />
+                <div className="flex flex-row w-full bg-red-500 items-center" style={{ height: "0.125rem" }}>
+                    <div className="bg-green-500 h-full" style={{ width: `${percentageVoted}%` }} />
                 </div>
             </div>
             <div className="flex flex-row mt-8 h-16 items-end">


### PR DESCRIPTION
Clearer grey to improve contrast and text for top-right buttons.

While pleasant to look at, the gears made it hard for people to find where to stake. 

Before
<img width="1355" alt="Screen Shot 2021-01-12 at 2 15 56 PM" src="https://user-images.githubusercontent.com/77356452/104376373-ea9e6500-54f2-11eb-9754-bd5317940871.png">
After
<img width="1365" alt="Screen Shot 2021-01-12 at 2 15 43 PM" src="https://user-images.githubusercontent.com/77356452/104376389-effbaf80-54f2-11eb-826b-b8f040d52c27.png">
